### PR TITLE
Register application commands in a task in Client.login

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -250,6 +250,13 @@ class Client:
         added to the client are the same (having the exact same name and options) as the previous
         time they were added. Defaults to ``True``.
 
+        .. note::
+
+            If this is set to ``True``, :meth:`register_application_commands` will be created as a task,
+            which means that the bot may connect to the gateway before all application commands are registered.
+            :func:`on_ready` and :meth:`wait_until_ready` will be delayed to wait for all application commands
+            to be registered.
+
         .. versionadded:: 2.0
 
     Attributes
@@ -565,7 +572,9 @@ class Client:
         self._connection.user = ClientUser(state=self._connection, data=data)
 
         if self.register_application_commands_on_startup:
-            await self.register_application_commands()
+            self._connection._application_command_task = asyncio.create_task(
+                self._connection._register_application_commands(), name='discord-register-application-commands'
+            )
 
     async def connect(self, *, reconnect: bool = True) -> None:
         """|coro|

--- a/discord/client.py
+++ b/discord/client.py
@@ -254,8 +254,8 @@ class Client:
 
             If this is set to ``True``, :meth:`register_application_commands` will be created as a task,
             which means that the bot may connect to the gateway before all application commands are registered.
-            :func:`on_ready` and :meth:`wait_until_ready` will be delayed to wait for all application commands
-            to be registered.
+            :func:`on_ready` and :meth:`wait_until_ready` will be delayed to wait for
+            :meth:`Client.register_application_commands` to finish, regardless of whether an error was raised in it or not.
 
         .. versionadded:: 2.0
 

--- a/discord/state.py
+++ b/discord/state.py
@@ -189,7 +189,7 @@ class ConnectionState:
     def __init__(
         self,
         *,
-        dispatch: Callable[..., None],
+        dispatch: Callable,
         handlers: Dict[str, Callable],
         hooks: Dict[str, Callable],
         http: HTTPClient,
@@ -239,7 +239,7 @@ class ConnectionState:
         intents = options.get('intents', None)
         if intents is not None:
             if not isinstance(intents, Intents):
-                raise TypeError(f'intents parameter must be Intents not {type(intents)!r}')
+                raise TypeError(f'intents parameter must be Intent not {type(intents)!r}')
         else:
             intents = Intents.default()
 
@@ -402,7 +402,7 @@ class ConnectionState:
     def store_view(self, view: View, message_id: Optional[int] = None) -> None:
         self._view_store.add_view(view, message_id)
 
-    def prevent_view_updates_for(self, message_id: Optional[int]) -> Optional[View]:
+    def prevent_view_updates_for(self, message_id: int) -> Optional[View]:
         return self._view_store.remove_message_tracking(message_id)
 
     @property
@@ -613,7 +613,7 @@ class ConnectionState:
         if self._ready_task is not None:
             self._ready_task.cancel()
 
-        self._ready_state: asyncio.Queue[Guild] = asyncio.Queue()
+        self._ready_state = asyncio.Queue()
         self.clear(views=False)
         self.user = ClientUser(state=self, data=data['user'])
         self.store_user(data['user'])


### PR DESCRIPTION
## Summary
This PR changes `Client.login` to create `Client.register_application_commands` as a task to not delay the bot connecting to the gateway. Any errors that happen when application commands are created in the task are printed to `sys.stderr`, instead of being raised. `Client.wait_until_ready` and `on_ready` are delayed to wait for the application commands to be registered. 

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
