### PR TITLE
Refactor application command option parsing

### DIFF
--- a/discord/application_commands.py
+++ b/discord/application_commands.py
@@ -750,34 +750,77 @@ class ApplicationCommandOptions:
                 options.extend(nested_options)
                 continue
 
-            value = option.get('value')
+            value: Any = option.get('value')
             # the option is a subcommand
             if value is None:
                 continue
 
+            resolved_data = resolved_data or {}
+
             if option['type'] == 6:  # user
-                resolved_user = resolved_data['users'][value]  # type: ignore
-                if guild_id is not None:
-                    guild = state._get_guild(guild_id) or Object(id=guild_id)
-                    member_with_user = {**resolved_data['members'][value], 'user': resolved_user}  # type: ignore
-                    value = Member(state=state, data=member_with_user, guild=guild)  # type: ignore
-                else:
-                    value = User(state=state, data=resolved_user, guild=guild)  # type: ignore
-            elif option['type'] == 7:  # channel
-                resolved_channel = resolved_data['channels'][value]  # type: ignore
+                try:
+                    resolved_user = resolved_data['users'][value]
+                except KeyError:
+                    resolved_user = None
+
                 if guild_id is not None:
                     guild = state._get_guild(guild_id)
-                    if guild is not None:
-                        value = guild._resolve_channel(int(resolved_channel['id']))  # there isn't enough data in the resolved channels from the payload
+                    user = guild and guild.get_member(int(value))
+                    if user is None:
+                        if resolved_user is not None:
+                            member_with_user = {**resolved_data['members'][value], 'user': resolved_user}  # type: ignore
+                            value = Member(state=state, data=member_with_user, guild=guild or Object(id=guild_id))  # type: ignore
+                        else:
+                            value = Object(id=int(value))
+                    else:
+                        value = user
+                else:
+                    if resolved_user is not None:
+                        value = User(state=state, data=resolved_user)
+                    else:
+                        value = Object(id=int(value))
+            elif option['type'] == 7:  # channel
+                guild = state._get_guild(guild_id)
+                if guild is not None:
+                    channel = guild._resolve_channel(int(value))
+                    if channel is None:  # there isn't enough data in the resolved channels from the payload
+                        channel = PartialMessageable(state=state, id=int(value))
+
+                    value = channel
+                else:
+                    value = PartialMessageable(state=state, id=int(value))
             elif option['type'] == 9:  # mention (role or user)
                 if guild_id is not None:
-                    guild = state._get_guild(guild_id) or Object(id=guild_id)
+                    guild = state._get_guild(guild_id)
                     try:
-                        value = Member(state=state, data=resolved_data['members'][value], guild=guild)  # type: ignore
+                        obj = guild and guild.get_member(int(value))
+                        if obj is None:
+                            try:
+                                resolved_user = resolved_data['users'][value]
+                                member_with_user = {**resolved_data['members'][value], 'user': resolved_user}  # type: ignore
+                                value = Member(state=state, data=member_with_user, guild=guild)  # type: ignore
+                            except KeyError:
+                                value = Object(int(value))
+                        else:
+                            value = obj
                     except KeyError:
-                        value = Role(guild=guild, state=state, data=resolved_data['roles'][value]) # type: ignore
+                        obj = guild and guild.get_role(int(value))
+                        if obj is None:
+                            try:
+                                value = Role(guild=guild or Object(id=guild_id), state=state, data=resolved_data['roles'][value])  # type: ignore
+                            except KeyError:
+                                value = Object(int(value))
+                        else:
+                            value = obj
                 else:
-                    value = User(state=state, data=resolved_data['users'][value])  # type: ignore
+                    obj = state.get_user(int(value))
+                    if obj is None:
+                        try:
+                            value = User(state=state, data=resolved_data['users'][value])
+                        except KeyError:
+                            value = Object(int(value))
+                    else:
+                        value = obj
 
             self.__application_command_options__[option['name']] = value
 

--- a/discord/application_commands.py
+++ b/discord/application_commands.py
@@ -793,17 +793,14 @@ class ApplicationCommandOptions:
             elif option_type == 8:  # role
                 guild = state._get_guild(guild_id)
                 role = guild and guild.get_role(int(value))
-                if role is None and guild is not None:
+                if role is None:
                     try:
                         resolved_role = resolved_data['roles'][value]
-                        # guild_id won't be None
                         value = Role(guild=guild or Object(id=guild_id), state=state, data=resolved_role)  # type: ignore
                     except KeyError:
                         value = Object(id=int(value))
-                elif role is None:
-                    role = Object(id=int(value))
                 else:
-                    role = value
+                    value = role
             elif option_type == 9:  # mention (role or user)
                 if guild_id is not None:
                     guild = state._get_guild(guild_id)


### PR DESCRIPTION
## Summary
This PR refactors application command option parsing, including attempting to get the object from the cache before creating a new object from the resolved data. This also fixes the parsing of options for autocomplete responses, where resolved data isn't provided.

## Checklist
- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
