### PR TITLE
Implement guild timeouts

### DIFF
--- a/discord/member.py
+++ b/discord/member.py
@@ -689,7 +689,7 @@ class Member(discord.abc.Messageable, _UserTag):
         +------------------------------+--------------------------------------+
         | voice_channel                | :attr:`Permissions.move_members`     |
         +------------------------------+--------------------------------------+
-        | timeout_until | :attr:`Permissions.moderate_members` |
+        | timeout_until                | :attr:`Permissions.moderate_members` |
         +------------------------------+--------------------------------------+
 
         All parameters are optional.

--- a/discord/member.py
+++ b/discord/member.py
@@ -253,7 +253,7 @@ class Member(discord.abc.Messageable, _UserTag):
     premium_since: Optional[:class:`datetime.datetime`]
         An aware datetime object that specifies the date and time in UTC when the member used their
         "Nitro boost" on the guild, if available. This could be ``None``.
-    communication_disabled_until: Optional[:class:`datetime.datetime`]
+    timeout_until: Optional[:class:`datetime.datetime`]
         An aware datetime object that specifies the date and time in UTC when the member will have their
         timeout removed. This could be ``None``.
     """
@@ -261,7 +261,7 @@ class Member(discord.abc.Messageable, _UserTag):
     __slots__ = (
         'joined_at',
         'premium_since',
-        'communication_disabled_until',
+        'timeout_until',
         'activities',
         'guild',
         'pending',
@@ -297,7 +297,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.guild: Guild = guild
         self.joined_at: Optional[datetime.datetime] = utils.parse_time(data.get('joined_at'))
         self.premium_since: Optional[datetime.datetime] = utils.parse_time(data.get('premium_since'))
-        self.communication_disabled_until: Optional[datetime.datetime] = utils.parse_time(data.get('communication_disabled_until'))
+        self.timeout_until: Optional[datetime.datetime] = utils.parse_time(data.get('communication_disabled_until'))
         self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data['roles']))
         self._client_status: Dict[Optional[str], str] = {None: 'offline'}
         self.activities: Tuple[ActivityTypes, ...] = tuple()
@@ -667,7 +667,7 @@ class Member(discord.abc.Messageable, _UserTag):
         suppress: bool = MISSING,
         roles: List[discord.abc.Snowflake] = MISSING,
         voice_channel: Optional[VocalGuildChannel] = MISSING,
-        communication_disabled_until: Optional[datetime.datetime] = MISSING,
+        timeout_until: Optional[datetime.datetime] = MISSING,
         reason: Optional[str] = None,
     ) -> Optional[Member]:
         """|coro|
@@ -689,7 +689,7 @@ class Member(discord.abc.Messageable, _UserTag):
         +------------------------------+--------------------------------------+
         | voice_channel                | :attr:`Permissions.move_members`     |
         +------------------------------+--------------------------------------+
-        | communication_disabled_until | :attr:`Permissions.moderate_members` |
+        | timeout_until | :attr:`Permissions.moderate_members` |
         +------------------------------+--------------------------------------+
 
         All parameters are optional.
@@ -718,7 +718,7 @@ class Member(discord.abc.Messageable, _UserTag):
         voice_channel: Optional[:class:`VoiceChannel`]
             The voice channel to move the member to.
             Pass ``None`` to kick them from voice.
-        communication_disabled_until: Optional[:class:`datetime.datetime`]
+        timeout_until: Optional[:class:`datetime.datetime`]
             A datetime object when indicating when the user should be timed out until.
             Pass ``None`` to remove their timeout.
         reason: Optional[:class:`str`]
@@ -777,14 +777,14 @@ class Member(discord.abc.Messageable, _UserTag):
         if roles is not MISSING:
             payload['roles'] = tuple(r.id for r in roles)
 
-        if communication_disabled_until is not MISSING:
-            if communication_disabled_until is None:
+        if timeout_until is not MISSING:
+            if timeout_until is None:
                 payload['communication_disabled_until'] = None
             else:
-                if communication_disabled_until.tzinfo:
-                    timestamp = communication_disabled_until.astimezone(tz=datetime.timezone.utc).isoformat()
+                if timeout_until.tzinfo:
+                    timestamp = timeout_until.astimezone(tz=datetime.timezone.utc).isoformat()
                 else:
-                    timestamp = communication_disabled_until.replace(tzinfo=datetime.timezone.utc).isoformat()
+                    timestamp = timeout_until.replace(tzinfo=datetime.timezone.utc).isoformat()
 
                 payload['communication_disabled_until'] = timestamp
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -254,7 +254,7 @@ class Member(discord.abc.Messageable, _UserTag):
         An aware datetime object that specifies the date and time in UTC when the member used their
         "Nitro boost" on the guild, if available. This could be ``None``.
     communication_disabled_until: Optional[:class:`datetime.datetime`]
-        An aware object that specifies the date and time in UTC when the member will have their
+        An aware datetime object that specifies the date and time in UTC when the member will have their
         timeout removed. This could be ``None``.
     """
 

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -153,7 +153,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(0b1111111111111111111111111111111111111111)
+        return cls(0b11111111111111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -565,6 +565,14 @@ class Permissions(BaseFlags):
         """
         return 1 << 39
 
+    @flag_value
+    def moderate_members(self) -> int:
+        """:class:`bool`: Returns ``True`` if a user can perform limited moderation actions (timeout).
+
+        .. versionadded:: 2.0
+        """
+        return 1 << 40
+
 PO = TypeVar('PO', bound='PermissionOverwrite')
 
 def _augment_from_permissions(cls):

--- a/discord/types/member.py
+++ b/discord/types/member.py
@@ -36,6 +36,7 @@ class PartialMember(TypedDict):
     joined_at: str
     deaf: str
     mute: str
+    communication_disabled_until: str
 
 
 class Member(PartialMember, total=False):


### PR DESCRIPTION
## Summary
This pull request implements guild timeouts (discord/discord-api-docs#4075)

- Adds `Permissions.moderate_members`
- Adds `Member.communication_disabled_until`
- Adds the `communication_disabled_until` kwarg of `Member.edit`

## Checklist
- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
