### PR TITLE
Add BaseApplicationCommand.full_parent_name and BaseApplicationComman…

### DIFF
--- a/discord/application_commands.py
+++ b/discord/application_commands.py
@@ -1572,6 +1572,23 @@ class BaseApplicationCommand:
     def global_command(self) -> bool:
         return self.__application_command_global_command__
 
+    @property
+    def full_parent_name(self) -> str:
+        entries = []
+        command = self
+        while command.__application_command_parent__ is not None:
+            command = command.__application_command_parent__
+            entries.append(command.__application_command_name__)
+
+        return ' '.join(reversed(entries))
+
+    @property
+    def qualified_name(self) -> str:
+        parent = self.full_parent_name
+        if parent:
+            return parent + ' ' + self.__application_command_name__
+        else:
+            return self.__application_command_name__
 
 class SlashCommand(BaseApplicationCommand, type=ApplicationCommandType.slash):
     """Represents a Discord slash command.


### PR DESCRIPTION
…d.qualified_name

## Summary
This PR adds two properties that allow the user to see how the command would be viewed in Discord.

## Checklist
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
