### PR TITLE
Use an enum for interaction locales

### DIFF
--- a/discord/enums.py
+++ b/discord/enums.py
@@ -653,6 +653,39 @@ class ScheduledEventStatus(Enum):
     cancelled = 4
 
 
+class Locale(Enum):
+    en_us = 'en-US'
+    en_gb = 'en-GB'
+    bg = 'bg'
+    zh_cn = 'zh-CN'
+    zh_tw = 'zh-TW'
+    hr = 'hr'
+    cs = 'cs'
+    da = 'da'
+    nl = 'nl'
+    fi = 'fi'
+    fr = 'fr'
+    de = 'de'
+    el = 'el'
+    hi = 'hi'
+    hu = 'hu'
+    it = 'it'
+    ja = 'ja'
+    ko = 'ko'
+    lt = 'lt'
+    no = 'no'
+    pl = 'pl'
+    pt_br = 'pt-BR'
+    ro = 'ro'
+    ru = 'ru'
+    es_es = 'es-ES'
+    sv_se = 'sv-SE'
+    th = 'th'
+    tr = 'tr'
+    uk = 'uk'
+    vi = 'vi'
+
+
 T = TypeVar('T')
 
 

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -172,10 +172,10 @@ class Interaction(Generic[ClientT]):
     token: :class:`str`
         The token to continue the interaction. These are valid
         for 15 minutes.
-    locale: Optional[:class:`Locale`]
+    locale: :class:`Locale`
         The selected locale of the user that sent the interaction, if
         :attr:`.type` is not :attr:`InteractionType.ping`.
-    guild_locale: Optional[:class:`Locale`]
+    guild_locale: :class:`Locale`
         The primary locale of the guild, if the interaction was sent from
         a guild. This is set in community settings.
     data: :class:`dict`

--- a/discord/interactions.py
+++ b/discord/interactions.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, TypeV
 import asyncio
 
 from . import utils
-from .enums import try_enum, InteractionType, InteractionResponseType
+from .enums import try_enum, InteractionType, InteractionResponseType, Locale
 from .errors import InteractionResponded, HTTPException, ClientException, InvalidArgument
 from .channel import PartialMessageable, ChannelType
 
@@ -172,11 +172,11 @@ class Interaction(Generic[ClientT]):
     token: :class:`str`
         The token to continue the interaction. These are valid
         for 15 minutes.
-    locale: Optional[:class:`str`]
-        The selected language of the user that sent the interaction.
-        If :attr:`.type` is :attr:`InteractionType.ping`, this will be ``None``.
-    guild_locale: Optional[:class:`str`]
-        The primary language of the guild, if the interaction was sent from
+    locale: Optional[:class:`Locale`]
+        The selected locale of the user that sent the interaction, if
+        :attr:`.type` is not :attr:`InteractionType.ping`.
+    guild_locale: Optional[:class:`Locale`]
+        The primary locale of the guild, if the interaction was sent from
         a guild. This is set in community settings.
     data: :class:`dict`
         The raw interaction data.
@@ -219,8 +219,8 @@ class Interaction(Generic[ClientT]):
         self.type: InteractionType = try_enum(InteractionType, data['type'])
         self.data: Optional[InteractionData] = data.get('data')
         self.token: str = data['token']
-        self.locale: Optional[str] = data.get('locale')
-        self.guild_locale: Optional[str] = data.get('guild_locale')
+        self.locale: Locale = try_enum(Locale, data.get('locale'))
+        self.guild_locale: Locale = try_enum(Locale, data.get('guild_locale'))
         self.version: int = data['version']
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, 'channel_id')
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, 'guild_id')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2833,6 +2833,132 @@ of :class:`enum.Enum`.
 
         Any float or integer between -2^53 and 2^53.
 
+..class:: Locale
+
+    Specifies the selected locale of a user or guild.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: en_us
+
+        The English (United States) locale.
+
+    .. attribute:: en_gb
+
+        The English (Great Britain) locale.
+
+    .. attribute:: bg
+
+        The bulgarian locale.
+
+    .. attribute:: zh_cn
+
+        The Chinese (China) locale.
+
+    .. attribute:: zh_tw
+
+        The Chinese (Taiwan) locale.
+
+    .. attribute:: hr
+
+        The Croation locale.
+
+    .. attribute:: cs
+
+        The Czech locale.
+
+    .. attribute:: da
+
+        The Danish locale.
+
+    .. attribute:: nl
+
+        The Dutch locale.
+
+    .. attribute:: fi
+
+        The Finnish locale.
+
+    .. attribute:: fr
+
+        The French locale.
+
+    .. attribute:: de
+
+        The German locale.
+
+    .. attribute:: el
+
+        The Greek locale.
+
+    .. attribute:: hi
+
+        The Hindi locale.
+
+    .. attribute:: hu
+
+        The Hungraian locale.
+
+    .. attribute:: it
+
+        The Italian locale.
+
+    .. attribute:: ja
+
+        The Japanese locale.
+
+    .. attribute:: ko
+
+        The Korean locale.
+
+    .. attribute:: lt
+
+        The Lithuanian locale.
+
+    .. attribute:: no
+
+        The Norweigian locale.
+
+    .. attribute:: pl
+
+        The Polish locale.
+
+    .. attribute:: pt_br
+
+        The Portuguese (Brazil) locale.
+
+    .. attribute:: ro
+
+        The Romanian locale.
+
+    .. attribute:: ru
+
+        The Russian locale.
+
+    .. attribute:: es_es
+
+        The Spanish (Spain) locale.
+
+    .. attribute:: sv_se
+
+        The Swedish locale.
+
+    .. attribute:: th
+
+        The Thai locale.
+
+    .. attribute:: tr
+
+        The Turkish locale.
+
+    .. attribute:: uk
+
+        The Ukranian locale.
+
+    .. attribute:: vi
+
+        The Vietnamese locale.
+
 Async Iterator
 ----------------
 


### PR DESCRIPTION
## Summary
This PR adds the `Locale` enum to be used for `Interaction.locale` and `Interaction.locale`. The description of those attributes were slightly changed as well.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
