### PR TITLE
Use typing_extensions.Self where applicable

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -233,9 +233,6 @@ class _Overwrites:
         return self.type == 1
 
 
-GCH = TypeVar('GCH', bound='GuildChannel')
-
-
 class GuildChannel:
     """An ABC that details the common operations on a Discord guild channel.
 
@@ -864,7 +861,7 @@ class GuildChannel:
         self.guild._channels[obj.id] = obj  # type: ignore
         return obj
 
-    async def clone(self: GCH, *, name: Optional[str] = None, reason: Optional[str] = None) -> GCH:
+    async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> Self:
         """|coro|
 
         Clones this channel. This creates a channel with the same properties

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -67,6 +67,8 @@ __all__ = (
 T = TypeVar('T', bound=VoiceProtocol)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from datetime import datetime
 
     from .client import Client
@@ -844,12 +846,12 @@ class GuildChannel:
             raise InvalidArgument('Invalid overwrite type provided.')
 
     async def _clone_impl(
-        self: GCH,
+        self,
         base_attrs: Dict[str, Any],
         *,
         name: Optional[str] = None,
         reason: Optional[str] = None,
-    ) -> GCH:
+    ) -> Self:
         base_attrs['permission_overwrites'] = [x._asdict() for x in self._overwrites]
         base_attrs['parent_id'] = self.category_id
         base_attrs['name'] = name or self.name

--- a/discord/application_commands.py
+++ b/discord/application_commands.py
@@ -1233,7 +1233,7 @@ class BaseApplicationCommand:
 
     @overload
     def __init_subclass__(
-        cls: Type[BaseApplicationCommand],
+        cls,
         *,
         name: Optional[str] = None,
         description: str = MISSING,
@@ -1248,7 +1248,7 @@ class BaseApplicationCommand:
 
     @overload
     def __init_subclass__(
-        cls: Type[BaseApplicationCommand],
+        cls,
         *,
         name: Optional[str] = None,
         description: str = MISSING,
@@ -1261,7 +1261,7 @@ class BaseApplicationCommand:
         ...
 
     def __init_subclass__(
-        cls: Type[BaseApplicationCommand],
+        cls,
         *,
         name: Optional[str] = None,
         description: str = MISSING,

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import io
 import os
-from typing import Any, Literal, Optional, TYPE_CHECKING, Tuple, Union, TypeVar, Type
+from typing import Any, Literal, Optional, TYPE_CHECKING, Tuple, Union
 from .errors import DiscordException
 from .errors import InvalidArgument
 from . import utils
@@ -38,13 +38,13 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .state import ConnectionState
     from .webhook.async_ import _WebhookState
 
     ValidStaticFormatTypes = Literal['webp', 'jpeg', 'jpg', 'png']
     ValidAssetFormatTypes = Literal['webp', 'jpeg', 'jpg', 'png', 'gif']
-
-    AT = TypeVar('AT', bound='Asset')
 
 VALID_STATIC_FORMATS = frozenset({"jpeg", "jpg", "webp", "png"})
 VALID_ASSET_FORMATS = VALID_STATIC_FORMATS | {"gif"}
@@ -163,7 +163,7 @@ class Asset(AssetMixin):
         self._key: str = key
 
     @classmethod
-    def _from_default_avatar(cls: Type[AT], state: Union[ConnectionState, _WebhookState], index: int) -> AT:
+    def _from_default_avatar(cls, state: Union[ConnectionState, _WebhookState], index: int) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/embed/avatars/{index}.png',
@@ -172,7 +172,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_avatar(cls: Type[AT], state: Union[ConnectionState, _WebhookState], user_id: int, avatar: str) -> AT:
+    def _from_avatar(cls, state: Union[ConnectionState, _WebhookState], user_id: int, avatar: str) -> Self:
         animated = avatar.startswith('a_')
         format = 'gif' if animated else 'png'
         return cls(
@@ -183,7 +183,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_guild_avatar(cls: Type[AT], state: Union[ConnectionState, _WebhookState], guild_id: int, member_id: int, avatar: str) -> AT:
+    def _from_guild_avatar(cls, state: Union[ConnectionState, _WebhookState], guild_id: int, member_id: int, avatar: str) -> Self:
         animated = avatar.startswith('a_')
         format = 'gif' if animated else 'png'
         return cls(
@@ -194,7 +194,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_icon(cls: Type[AT], state: Union[ConnectionState, _WebhookState], object_id: int, icon_hash: str, path: str) -> AT:
+    def _from_icon(cls, state: Union[ConnectionState, _WebhookState], object_id: int, icon_hash: str, path: str) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/{path}-icons/{object_id}/{icon_hash}.png?size=1024',
@@ -203,7 +203,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_cover_image(cls: Type[AT], state: Union[ConnectionState, _WebhookState], object_id: int, cover_image_hash: str) -> AT:
+    def _from_cover_image(cls, state: Union[ConnectionState, _WebhookState], object_id: int, cover_image_hash: str) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/app-assets/{object_id}/store/{cover_image_hash}.png?size=1024',
@@ -212,7 +212,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_guild_image(cls: Type[AT], state: Union[ConnectionState, _WebhookState], guild_id: int, image: str, path: str) -> AT:
+    def _from_guild_image(cls, state: Union[ConnectionState, _WebhookState], guild_id: int, image: str, path: str) -> Self:
         animated = image.startswith('a_')
         format = 'gif' if animated else 'png'
         return cls(
@@ -223,7 +223,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_guild_icon(cls: Type[AT], state: Union[ConnectionState, _WebhookState], guild_id: int, icon_hash: str) -> AT:
+    def _from_guild_icon(cls, state: Union[ConnectionState, _WebhookState], guild_id: int, icon_hash: str) -> Self:
         animated = icon_hash.startswith('a_')
         format = 'gif' if animated else 'png'
         return cls(
@@ -234,7 +234,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_sticker_banner(cls: Type[AT], state: Union[ConnectionState, _WebhookState], banner: int) -> AT:
+    def _from_sticker_banner(cls, state: Union[ConnectionState, _WebhookState], banner: int) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/app-assets/710982414301790216/store/{banner}.png',
@@ -243,7 +243,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_user_banner(cls: Type[AT], state: Union[ConnectionState, _WebhookState], user_id: int, banner_hash: str) -> AT:
+    def _from_user_banner(cls, state: Union[ConnectionState, _WebhookState], user_id: int, banner_hash: str) -> Self:
         animated = banner_hash.startswith('a_')
         format = 'gif' if animated else 'png'
         return cls(

--- a/discord/asset.py
+++ b/discord/asset.py
@@ -254,7 +254,7 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_scheduled_event_image(cls: Type[AT], state: Union[ConnectionState, _WebhookState], scheduled_event_id: int, cover_hash: str) -> AT:
+    def _from_scheduled_event_image(cls, state: Union[ConnectionState, _WebhookState], scheduled_event_id: int, cover_hash: str) -> Self:
         return cls(
             state,
             url=f'{cls.BASE}/guild-events/{scheduled_event_id}/{cover_hash}.png?size=1024',

--- a/discord/channel.py
+++ b/discord/channel.py
@@ -27,17 +27,15 @@ from __future__ import annotations
 import time
 import asyncio
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
-    Iterable,
     List,
+    Callable,
+    Iterable,
     Mapping,
     Optional,
-    TYPE_CHECKING,
     Tuple,
-    Type,
-    TypeVar,
     Union,
     overload,
 )
@@ -68,6 +66,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .types.threads import ThreadArchiveDuration
     from .role import Role
     from .member import Member, VoiceState
@@ -199,7 +199,7 @@ class TextChannel(discord.abc.Messageable, discord.abc.GuildChannel, Hashable):
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, 'last_message_id')
         self._fill_overwrites(data)
 
-    async def _get_channel(self):
+    async def _get_channel(self) -> Self:
         return self
 
     @property
@@ -1700,9 +1700,6 @@ class StoreChannel(discord.abc.GuildChannel, Hashable):
             return self.__class__(state=self._state, guild=self.guild, data=payload)
 
 
-DMC = TypeVar('DMC', bound='DMChannel')
-
-
 class DMChannel(discord.abc.Messageable, Hashable):
     """Represents a Discord direct message channel.
 
@@ -1744,7 +1741,7 @@ class DMChannel(discord.abc.Messageable, Hashable):
         self.me: ClientUser = me
         self.id: int = int(data['id'])
 
-    async def _get_channel(self):
+    async def _get_channel(self) -> Self:
         return self
 
     def __str__(self) -> str:
@@ -1756,8 +1753,8 @@ class DMChannel(discord.abc.Messageable, Hashable):
         return f'<DMChannel id={self.id} recipient={self.recipient!r}>'
 
     @classmethod
-    def _from_message(cls: Type[DMC], state: ConnectionState, channel_id: int) -> DMC:
-        self: DMC = cls.__new__(cls)
+    def _from_message(cls, state: ConnectionState, channel_id: int) -> Self:
+        self = cls.__new__(cls)
         self._state = state
         self.id = channel_id
         self.recipient = None
@@ -1888,7 +1885,7 @@ class GroupChannel(discord.abc.Messageable, Hashable):
         else:
             self.owner = utils.find(lambda u: u.id == self.owner_id, self.recipients)
 
-    async def _get_channel(self):
+    async def _get_channel(self) -> Self:
         return self
 
     def __str__(self) -> str:

--- a/discord/cog.py
+++ b/discord/cog.py
@@ -30,6 +30,8 @@ from ._types import _BaseCommand
 from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Type, Union
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .ext.commands.context import Context
     from .ext.commands.core import Command
     from .ext.commands.bot import Bot
@@ -61,7 +63,6 @@ __all__ = (
     'Cog',
 )
 
-CogT = TypeVar('CogT', bound='Cog')
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 
 
@@ -129,7 +130,7 @@ class CogMeta(type):
     __cog_commands__: List[Command[Any, Any, Any]]
     __cog_listeners__: List[Tuple[str, str]]
 
-    def __new__(cls: Type[CogMeta], *args: Any, **kwargs: Any) -> CogMeta:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         name, bases, attrs = args
         attrs['__cog_name__'] = kwargs.pop('name', name)
         attrs['__cog_settings__'] = kwargs.pop('command_attrs', {})
@@ -210,7 +211,7 @@ class Cog(metaclass=CogMeta):
     __cog_listeners__: ClassVar[List[Tuple[str, str]]]
     __cog_application_commands__: Dict[ApplicationCommandKey, ApplicationCommand] = {}
 
-    def __new__(cls: Type[CogT], *args: Any, **kwargs: Any) -> CogT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # For issue 426, we need to store a copy of the command objects
         # since we modify them to inject `self` to them.
         # To do this, we need to interfere with the Cog creation process.
@@ -491,7 +492,7 @@ class Cog(metaclass=CogMeta):
         """
         pass
 
-    def _inject(self: CogT, client: Union[Client, Bot]) -> CogT:
+    def _inject(self, client: Union[Client, Bot]) -> Self:
         cls = self.__class__
         client_no_commands = "Client doesn't support ext.commands commands."
 

--- a/discord/colour.py
+++ b/discord/colour.py
@@ -32,18 +32,18 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypeVar,
     Union,
     Callable,
     TYPE_CHECKING,
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 __all__ = (
     'Colour',
     'Color',
 )
-
-CT = TypeVar('CT', bound='Colour')
 
 
 class Colour:
@@ -129,23 +129,23 @@ class Colour:
         return (self.r, self.g, self.b)
 
     @classmethod
-    def from_rgb(cls: Type[CT], r: int, g: int, b: int) -> CT:
+    def from_rgb(cls, r: int, g: int, b: int) -> Self:
         """Constructs a :class:`Colour` from an RGB tuple."""
         return cls((r << 16) + (g << 8) + b)
 
     @classmethod
-    def from_hsv(cls: Type[CT], h: float, s: float, v: float) -> CT:
+    def from_hsv(cls, h: float, s: float, v: float) -> Self:
         """Constructs a :class:`Colour` from an HSV tuple."""
         rgb = colorsys.hsv_to_rgb(h, s, v)
         return cls.from_rgb(*(int(x * 255) for x in rgb))
 
     @classmethod
-    def default(cls: Type[CT]) -> CT:
+    def default(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0``."""
         return cls(0)
 
     @classmethod
-    def random(cls: Type[CT], *, seed: Optional[Union[int, str, float, bytes, bytearray]] = None) -> CT:
+    def random(cls, *, seed: Optional[Union[int, str, float, bytes, bytearray]] = None) -> Self:
         """A factory method that returns a :class:`Colour` with a random hue.
 
         .. note::
@@ -166,17 +166,17 @@ class Colour:
         return cls.from_hsv(rand.random(), 1, 1)
 
     @classmethod
-    def teal(cls: Type[CT]) -> CT:
+    def teal(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x1abc9c``."""
         return cls(0x1abc9c)
 
     @classmethod
-    def dark_teal(cls: Type[CT]) -> CT:
+    def dark_teal(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x11806a``."""
         return cls(0x11806a)
 
     @classmethod
-    def brand_green(cls: Type[CT]) -> CT:
+    def brand_green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x57F287``.
 
         .. versionadded:: 2.0
@@ -184,67 +184,67 @@ class Colour:
         return cls(0x57F287)
 
     @classmethod
-    def green(cls: Type[CT]) -> CT:
+    def green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x2ecc71``."""
         return cls(0x2ecc71)
 
     @classmethod
-    def dark_green(cls: Type[CT]) -> CT:
+    def dark_green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x1f8b4c``."""
         return cls(0x1f8b4c)
 
     @classmethod
-    def blue(cls: Type[CT]) -> CT:
+    def blue(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x3498db``."""
         return cls(0x3498db)
 
     @classmethod
-    def dark_blue(cls: Type[CT]) -> CT:
+    def dark_blue(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x206694``."""
         return cls(0x206694)
 
     @classmethod
-    def purple(cls: Type[CT]) -> CT:
+    def purple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x9b59b6``."""
         return cls(0x9b59b6)
 
     @classmethod
-    def dark_purple(cls: Type[CT]) -> CT:
+    def dark_purple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x71368a``."""
         return cls(0x71368a)
 
     @classmethod
-    def magenta(cls: Type[CT]) -> CT:
+    def magenta(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe91e63``."""
         return cls(0xe91e63)
 
     @classmethod
-    def dark_magenta(cls: Type[CT]) -> CT:
+    def dark_magenta(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xad1457``."""
         return cls(0xad1457)
 
     @classmethod
-    def gold(cls: Type[CT]) -> CT:
+    def gold(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xf1c40f``."""
         return cls(0xf1c40f)
 
     @classmethod
-    def dark_gold(cls: Type[CT]) -> CT:
+    def dark_gold(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xc27c0e``."""
         return cls(0xc27c0e)
 
     @classmethod
-    def orange(cls: Type[CT]) -> CT:
+    def orange(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe67e22``."""
         return cls(0xe67e22)
 
     @classmethod
-    def dark_orange(cls: Type[CT]) -> CT:
+    def dark_orange(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xa84300``."""
         return cls(0xa84300)
 
     @classmethod
-    def brand_red(cls: Type[CT]) -> CT:
+    def brand_red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xED4245``.
 
         .. versionadded:: 2.0
@@ -252,17 +252,17 @@ class Colour:
         return cls(0xED4245)
 
     @classmethod
-    def red(cls: Type[CT]) -> CT:
+    def red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe74c3c``."""
         return cls(0xe74c3c)
 
     @classmethod
-    def dark_red(cls: Type[CT]) -> CT:
+    def dark_red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x992d22``."""
         return cls(0x992d22)
 
     @classmethod
-    def lighter_grey(cls: Type[CT]) -> CT:
+    def lighter_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x95a5a6``."""
         return cls(0x95a5a6)
 
@@ -272,7 +272,7 @@ class Colour:
         lighter_gray = lighter_grey
 
     @classmethod
-    def dark_grey(cls: Type[CT]) -> CT:
+    def dark_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x607d8b``."""
         return cls(0x607d8b)
 
@@ -282,7 +282,7 @@ class Colour:
         dark_gray = dark_grey
 
     @classmethod
-    def light_grey(cls: Type[CT]) -> CT:
+    def light_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x979c9f``."""
         return cls(0x979c9f)
 
@@ -292,7 +292,7 @@ class Colour:
         light_gray = light_grey
 
     @classmethod
-    def darker_grey(cls: Type[CT]) -> CT:
+    def darker_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x546e7a``."""
         return cls(0x546e7a)
 
@@ -302,22 +302,22 @@ class Colour:
         darker_gray = darker_grey
 
     @classmethod
-    def og_blurple(cls: Type[CT]) -> CT:
+    def og_blurple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x7289da``."""
         return cls(0x7289da)
 
     @classmethod
-    def blurple(cls: Type[CT]) -> CT:
+    def blurple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x5865F2``."""
         return cls(0x5865F2)
 
     @classmethod
-    def greyple(cls: Type[CT]) -> CT:
+    def greyple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x99aab5``."""
         return cls(0x99aab5)
 
     @classmethod
-    def dark_theme(cls: Type[CT]) -> CT:
+    def dark_theme(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x36393F``.
         This will appear transparent on Discord's dark theme.
 
@@ -326,7 +326,7 @@ class Colour:
         return cls(0x36393F)
 
     @classmethod
-    def fuchsia(cls: Type[CT]) -> CT:
+    def fuchsia(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xEB459E``.
 
         .. versionadded:: 2.0
@@ -334,7 +334,7 @@ class Colour:
         return cls(0xEB459E)
 
     @classmethod
-    def yellow(cls: Type[CT]) -> CT:
+    def yellow(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xFEE75C``.
 
         .. versionadded:: 2.0

--- a/discord/components.py
+++ b/discord/components.py
@@ -24,12 +24,14 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union
+from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
 from .enums import try_enum, ComponentType, ButtonStyle
 from .utils import get_slots, MISSING
 from .partial_emoji import PartialEmoji, _EmojiTag
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .types.components import (
         Component as ComponentPayload,
         ButtonComponent as ButtonComponentPayload,
@@ -47,8 +49,6 @@ __all__ = (
     'SelectMenu',
     'SelectOption',
 )
-
-C = TypeVar('C', bound='Component')
 
 
 class Component:
@@ -80,8 +80,8 @@ class Component:
         return f'<{self.__class__.__name__} {attrs}>'
 
     @classmethod
-    def _raw_construct(cls: Type[C], **kwargs: Any) -> C:
-        self: C = cls.__new__(cls)
+    def _raw_construct(cls, **kwargs: Any) -> Self:
+        self = cls.__new__(cls)
         for slot in get_slots(cls):
             try:
                 value = kwargs[slot]

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -25,14 +25,14 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, TypeVar, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Messageable
 
     from types import TracebackType
-
-    TypingT = TypeVar('TypingT', bound='Typing')
 
 __all__ = (
     'Typing',
@@ -62,7 +62,7 @@ class Typing:
             await typing(channel.id)
             await asyncio.sleep(5)
 
-    def __enter__(self: TypingT) -> TypingT:
+    def __enter__(self) -> Self:
         self.task: asyncio.Task[None] = self.loop.create_task(self.do_typing())
         self.task.add_done_callback(_typing_done_callback)
         return self
@@ -74,7 +74,7 @@ class Typing:
     ) -> None:
         self.task.cancel()
 
-    async def __aenter__(self: TypingT) -> TypingT:
+    async def __aenter__(self) -> Self:
         self._channel = channel = await self.messageable._get_channel()
         await channel._state.http.send_typing(channel.id)
         return self.__enter__()

--- a/discord/embeds.py
+++ b/discord/embeds.py
@@ -64,9 +64,9 @@ class EmbedProxy:
         return EmptyEmbed
 
 
-E = TypeVar('E', bound='Embed')
-
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from discord.types.embed import Embed as EmbedData, EmbedType
 
     T = TypeVar('T')
@@ -207,7 +207,7 @@ class Embed:
             self._timestamp: Union[datetime.datetime, _EmptyEmbed, None] = timestamp
 
     @classmethod
-    def from_dict(cls: Type[E], data: Mapping[str, Any]) -> E:
+    def from_dict(cls, data: Mapping[str, Any]) -> Self:
         """Converts a :class:`dict` to a :class:`Embed` provided it is in the
         format that Discord expects it to be in.
 
@@ -223,7 +223,7 @@ class Embed:
             The dictionary to convert into an embed.
         """
         # we are bypassing __init__ here since it doesn't apply here
-        self: E = cls.__new__(cls)
+        self = cls.__new__(cls)
 
         # fill in the basic fields
 
@@ -263,7 +263,7 @@ class Embed:
 
         return self
 
-    def copy(self: E) -> E:
+    def copy(self) -> Self:
         """Returns a shallow copy of the embed."""
         return self.__class__.from_dict(self.to_dict())
 
@@ -353,7 +353,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, '_footer', {}))  # type: ignore
 
-    def set_footer(self: E, *, text: MaybeEmpty[Any] = EmptyEmbed, icon_url: MaybeEmpty[Any] = EmptyEmbed) -> E:
+    def set_footer(self, *, text: MaybeEmpty[Any] = EmptyEmbed, icon_url: MaybeEmpty[Any] = EmptyEmbed) -> Self:
         """Sets the footer for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -376,7 +376,7 @@ class Embed:
 
         return self
     
-    def remove_footer(self: E) -> E:
+    def remove_footer(self) -> Self:
         """Clears embed's footer information.
 
         This function returns the class instance to allow for fluent-style
@@ -406,7 +406,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, '_image', {}))  # type: ignore
 
-    def set_image(self: E, *, url: MaybeEmpty[Any]) -> E:
+    def set_image(self, *, url: MaybeEmpty[Any]) -> Self:
         """Sets the image for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -448,7 +448,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, '_thumbnail', {}))  # type: ignore
 
-    def set_thumbnail(self: E, *, url: MaybeEmpty[Any]) -> E:
+    def set_thumbnail(self, *, url: MaybeEmpty[Any]) -> Self:
         """Sets the thumbnail for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -509,7 +509,7 @@ class Embed:
         """
         return EmbedProxy(getattr(self, '_author', {}))  # type: ignore
 
-    def set_author(self: E, *, name: Any, url: MaybeEmpty[Any] = EmptyEmbed, icon_url: MaybeEmpty[Any] = EmptyEmbed) -> E:
+    def set_author(self, *, name: Any, url: MaybeEmpty[Any] = EmptyEmbed, icon_url: MaybeEmpty[Any] = EmptyEmbed) -> Self:
         """Sets the author for the embed content.
 
         This function returns the class instance to allow for fluent-style
@@ -537,7 +537,7 @@ class Embed:
 
         return self
 
-    def remove_author(self: E) -> E:
+    def remove_author(self) -> Self:
         """Clears embed's author information.
 
         This function returns the class instance to allow for fluent-style
@@ -562,7 +562,7 @@ class Embed:
         """
         return [EmbedProxy(d) for d in getattr(self, '_fields', [])]  # type: ignore
 
-    def add_field(self: E, *, name: Any, value: Any, inline: bool = True) -> E:
+    def add_field(self, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Adds a field to the embed object.
 
         This function returns the class instance to allow for fluent-style
@@ -591,7 +591,7 @@ class Embed:
 
         return self
 
-    def insert_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
+    def insert_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Inserts a field before a specified index to the embed.
 
         This function returns the class instance to allow for fluent-style
@@ -652,7 +652,7 @@ class Embed:
         except (AttributeError, IndexError):
             pass
 
-    def set_field_at(self: E, index: int, *, name: Any, value: Any, inline: bool = True) -> E:
+    def set_field_at(self, index: int, *, name: Any, value: Any, inline: bool = True) -> Self:
         """Modifies a field to the embed object.
 
         The index must point to a valid pre-existing field.

--- a/discord/enums.py
+++ b/discord/enums.py
@@ -26,7 +26,22 @@ from __future__ import annotations
 
 import types
 from collections import namedtuple
-from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING, Type, TypeVar, Type, Tuple, NoReturn, Iterator, Mapping
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    TYPE_CHECKING, 
+    Type,
+    TypeVar,
+    Type,
+    Tuple,
+    NoReturn,
+    Iterator,
+    Mapping,
+    NamedTuple,
+    )
 
 __all__ = (
     'Enum',
@@ -65,11 +80,11 @@ __all__ = (
     'Locale',
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
-EMT = TypeVar('EMT', bound='EnumMeta')
 
-
-def _create_value_cls(name, comparable):
+def _create_value_cls(name: str, comparable: bool) -> Type[NamedTuple]:
     cls = namedtuple('_EnumValue_' + name, 'name value')
     cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'  # type: ignore
     cls.__str__ = lambda self: f'{name}.{self.name}'  # type: ignore
@@ -80,7 +95,7 @@ def _create_value_cls(name, comparable):
         cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value # type: ignore
     return cls
 
-def _is_descriptor(obj):
+def _is_descriptor(obj: Any) -> bool:
     return hasattr(obj, '__get__') or hasattr(obj, '__set__') or hasattr(obj, '__delete__')
 
 
@@ -91,7 +106,7 @@ class EnumMeta(type):
         _enum_member_map_: ClassVar[Dict[str, Any]]
         _enum_value_map_: ClassVar[Dict[Any, Any]]
 
-    def __new__(cls: Type[EMT], name: str, bases: Tuple[type, ...], attrs: Dict[str, Any], *, comparable: bool = False) -> EMT:
+    def __new__(cls, name: str, bases: Tuple[type, ...], attrs: Dict[str, Any], *, comparable: bool = False) -> Self:
         value_mapping = {}
         member_mapping = {}
         member_names = []
@@ -171,13 +186,12 @@ class EnumMeta(type):
 
 if TYPE_CHECKING:
     import enum
-    ET = TypeVar('ET')
 
     class Enum(enum.Enum):
-        def __le__(self: ET, other: ET) -> bool: ...
-        def __ge__(self: ET, other: ET) -> bool: ...
-        def __lt__(self: ET, other: ET) -> bool: ...
-        def __gt__(self: ET, other: ET) -> bool: ...
+        def __le__(self, other: Self) -> bool: ...
+        def __ge__(self, other: Self) -> bool: ...
+        def __lt__(self, other: Self) -> bool: ...
+        def __gt__(self, other: Self) -> bool: ...
 else:
 
     class Enum(metaclass=EnumMeta):

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -34,7 +34,7 @@ import discord.utils
 from discord.message import Message
 
 if TYPE_CHECKING:
-    from typing_extensions import ParamSpec
+    from typing_extensions import ParamSpec, Self
 
     from discord.abc import MessageableChannel
     from discord.guild import Guild

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -47,6 +47,8 @@ import discord
 from .errors import *
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .context import Context
     from .bot import Bot
 

--- a/discord/ext/commands/cooldowns.py
+++ b/discord/ext/commands/cooldowns.py
@@ -35,6 +35,8 @@ from discord.abc import PrivateChannel
 from .errors import MaxConcurrencyReached
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from discord.message import Message
 
     T = TypeVar('T')
@@ -355,7 +357,7 @@ class MaxConcurrency:
         if not isinstance(per, BucketType):
             raise TypeError(f'max_concurrency \'per\' must be of type BucketType not {type(per)!r}')
 
-    def copy(self: MC) -> MC:
+    def copy(self) -> Self:
         return self.__class__(self.number, per=self.per, wait=self.wait)
 
     def __repr__(self) -> str:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -55,7 +55,7 @@ from .context import Context
 
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec, TypeGuard
+    from typing_extensions import Concatenate, ParamSpec, TypeGuard, Self
 
     from discord.message import Message
 
@@ -293,7 +293,7 @@ class Command(discord._types._BaseCommand, Generic[CogT, P, T]):
     """
     __original_kwargs__: Dict[str, Any]
 
-    def __new__(cls: Type[CommandT], *args: Any, **kwargs: Any) -> CommandT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # if you're wondering why this is done, it's because we need to ensure
         # we have a complete original copy of **kwargs even for classes that
         # mess with it by popping before delegating to the subclass __init__.
@@ -500,7 +500,7 @@ class Command(discord._types._BaseCommand, Generic[CogT, P, T]):
             pass
         return other
 
-    def copy(self: CommandT) -> CommandT:
+    def copy(self) -> Self:
         """Creates a copy of this command.
 
         Returns
@@ -511,7 +511,7 @@ class Command(discord._types._BaseCommand, Generic[CogT, P, T]):
         ret = self.__class__(self.callback, **self.__original_kwargs__)
         return self._ensure_assignment_on_copy(ret)
 
-    def _update_copy(self: CommandT, kwargs: Dict[str, Any]) -> CommandT:
+    def _update_copy(self, kwargs: Dict[str, Any]) -> Self:
         if kwargs:
             kw = kwargs.copy()
             kw.update(self.__original_kwargs__)
@@ -1422,7 +1422,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
         self.invoke_without_command: bool = attrs.pop('invoke_without_command', False)
         super().__init__(*args, **attrs)
 
-    def copy(self: GroupT) -> GroupT:
+    def copy(self) -> Self:
         """Creates a copy of this :class:`Group`.
 
         Returns

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -70,8 +70,6 @@ if TYPE_CHECKING:
 
     from .context import Context
 
-    FMT = TypeVar('FMT', bound='FlagsMeta')
-
 @dataclass
 class Flag:
     """Represents a flag parameter for :class:`FlagConverter`.
@@ -433,9 +431,6 @@ async def convert_flag(ctx: Context[Any], argument: str, flag: Flag, annotation:
         raise
     except Exception as e:
         raise BadFlagArgument(flag) from e
-
-
-F = TypeVar('F', bound='FlagConverter')
 
 
 class FlagConverter(metaclass=FlagsMeta):

--- a/discord/ext/commands/flags.py
+++ b/discord/ext/commands/flags.py
@@ -66,6 +66,8 @@ __all__ = (
 
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .context import Context
 
     FMT = TypeVar('FMT', bound='FlagsMeta')
@@ -266,7 +268,7 @@ class FlagsMeta(type):
         __commands_flag_prefix__: str
 
     def __new__(
-        cls: Type[FMT],
+        cls,
         name: str,
         bases: Tuple[type, ...],
         attrs: Dict[str, Any],
@@ -274,7 +276,7 @@ class FlagsMeta(type):
         case_insensitive: bool = MISSING,
         delimiter: str = MISSING,
         prefix: str = MISSING,
-    ) -> FMT:
+    ) -> Self:
         attrs['__commands_is_flag__'] = True
 
         try:
@@ -482,8 +484,8 @@ class FlagConverter(metaclass=FlagsMeta):
             yield (flag.name, getattr(self, flag.attribute))
 
     @classmethod
-    async def _construct_default(cls: Type[F], ctx: Context[Any]) -> F:
-        self: F = cls.__new__(cls)
+    async def _construct_default(cls, ctx: Context[Any]) -> Self:
+        self = cls.__new__(cls)
         flags = cls.__commands_flags__
         for flag in flags.values():
             if callable(flag.default):
@@ -548,7 +550,7 @@ class FlagConverter(metaclass=FlagsMeta):
         return result
 
     @classmethod
-    async def convert(cls: Type[F], ctx: Context[Any], argument: str) -> F:
+    async def convert(cls, ctx: Context[Any], argument: str) -> Self:
         """|coro|
 
         The method that actually converters an argument to the flag mapping.
@@ -577,7 +579,7 @@ class FlagConverter(metaclass=FlagsMeta):
         arguments = cls.parse_flags(argument)
         flags = cls.__commands_flags__
 
-        self: F = cls.__new__(cls)
+        self = cls.__new__(cls)
         for name, flag in flags.items():
             try:
                 values = arguments[name]

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -62,7 +62,6 @@ if TYPE_CHECKING:
 
     import inspect
 
-    HCT = TypeVar('HCT', bound='HelpCommand')
     CommandMapping = Mapping[Optional[Cog], List[Command[Any, Any, Any]]]
 
 __all__ = (

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -51,6 +51,8 @@ from .core import Group, Command
 from .errors import CommandError
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ._types import Check
 
     from .context import Context
@@ -337,7 +339,7 @@ class HelpCommand:
 
     MENTION_PATTERN = re.compile('|'.join(MENTION_TRANSFORMS.keys()))
 
-    def __new__(cls: Type[HCT], *args: Any, **kwargs: Any) -> HCT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # To prevent race conditions of a single instance while also allowing
         # for settings to be passed the original arguments passed must be assigned
         # to allow for easier copies (which will be made when the help command is actually called)
@@ -362,7 +364,7 @@ class HelpCommand:
         self.context: Context[Any] = discord.utils.MISSING
         self._command_impl: _HelpCommandImpl = _HelpCommandImpl(self, **self.command_attrs)
 
-    def copy(self: HCT) -> HCT:
+    def copy(self) -> Self:
         obj = self.__class__(*self.__original_args__, **self.__original_kwargs__)
         obj._command_impl = self._command_impl
         return obj

--- a/discord/ext/tasks/__init__.py
+++ b/discord/ext/tasks/__init__.py
@@ -66,7 +66,6 @@ T = TypeVar('T')
 Coro = Coroutine[Any, Any, T]
 CoroFunc = TypeVar('CoroFunc', bound=Callable[..., Coro[Any]])
 ET = TypeVar('ET', bound=Callable[[Any, BaseException], Coroutine[Any, Any, Any]])
-LT = TypeVar('LT', bound='Loop')
 
 
 class SleepHandle:
@@ -754,5 +753,5 @@ def loop(
             'reconnect': reconnect,
             'loop': loop,
         }
-        return Loop[C, P, T](func, **kwargs)
+        return Loop(func, **kwargs)
     return decorator

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Callable, ClassVar, Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, overload
 
 from .enums import UserFlags
 
@@ -37,6 +37,9 @@ __all__ = (
     'ApplicationFlags',
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 FV = TypeVar('FV', bound='flag_value')
 BF = TypeVar('BF', bound='BaseFlags')
 
@@ -47,7 +50,7 @@ class flag_value:
         self.__doc__: Optional[str] = func.__doc__
 
     @overload
-    def __get__(self: FV, instance: None, owner: Type[BF]) -> FV:
+    def __get__(self, instance: None, owner: Type[BF]) -> Self:
         ...
 
     @overload
@@ -108,7 +111,7 @@ class BaseFlags:
             setattr(self, key, value)
 
     @classmethod
-    def _from_value(cls: Type[BF], value: int) -> BF:
+    def _from_value(cls, value: int) -> Self:
         self = cls.__new__(cls)
         self.value = value
         return self
@@ -474,7 +477,7 @@ class Intents(BaseFlags):
             setattr(self, key, value)
 
     @classmethod
-    def all(cls: Type[Intents]) -> Intents:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything enabled."""
         bits = max(cls.VALID_FLAGS.values()).bit_length()
         value = (1 << bits) - 1
@@ -483,14 +486,14 @@ class Intents(BaseFlags):
         return self
 
     @classmethod
-    def none(cls: Type[Intents]) -> Intents:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything disabled."""
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
         return self
 
     @classmethod
-    def default(cls: Type[Intents]) -> Intents:
+    def default(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything enabled
         except :attr:`presences` and :attr:`members`.
         """

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -957,7 +957,7 @@ class MemberCacheFlags(BaseFlags):
             setattr(self, key, value)
 
     @classmethod
-    def all(cls: Type[MemberCacheFlags]) -> MemberCacheFlags:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` with everything enabled."""
         bits = max(cls.VALID_FLAGS.values()).bit_length()
         value = (1 << bits) - 1
@@ -966,7 +966,7 @@ class MemberCacheFlags(BaseFlags):
         return self
 
     @classmethod
-    def none(cls: Type[MemberCacheFlags]) -> MemberCacheFlags:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` with everything disabled."""
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
@@ -998,7 +998,7 @@ class MemberCacheFlags(BaseFlags):
         return 2
 
     @classmethod
-    def from_intents(cls: Type[MemberCacheFlags], intents: Intents) -> MemberCacheFlags:
+    def from_intents(cls, intents: Intents) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` based on
         the currently selected :class:`Intents`.
 

--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -61,6 +61,8 @@ from .enums import SpeakingState
 from .errors import ConnectionClosed, InvalidArgument 
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .client import Client
     from .state import ConnectionState
     from .voice_client import VoiceClient
@@ -68,8 +70,6 @@ if TYPE_CHECKING:
     from .types.voice import SessionDescription
 
     T = TypeVar('T')
-    DWS = TypeVar('DWS', bound='DiscordWebSocket')
-    DVWS = TypeVar('DVWS', bound='DiscordVoiceWebSocket')
 
     Coro = Callable[..., Coroutine[Any, Any, Any]]
     Predicate = Callable[[Dict[str, Any]], bool]
@@ -365,7 +365,7 @@ class DiscordWebSocket:
 
     @classmethod
     async def from_client(
-        cls: Type[DWS],
+        cls,
         client: Client,
         *,
         initial: bool = False,
@@ -374,7 +374,7 @@ class DiscordWebSocket:
         session: Optional[str] = None,
         sequence: Optional[int] = None,
         resume: bool = False
-    ) -> DWS:
+    ) -> Self:
         """Creates a main websocket for Discord from a :class:`Client`.
 
         This is for internal use only.
@@ -845,7 +845,7 @@ class DiscordVoiceWebSocket:
         await self.send_as_json(payload)
 
     @classmethod
-    async def from_client(cls: Type[DVWS], client: VoiceClient, *, resume: bool = False, hook: Optional[Coro] = None) -> DVWS:
+    async def from_client(cls, client: VoiceClient, *, resume: bool = False, hook: Optional[Coro] = None) -> Self:
         """Creates a voice websocket for the :class:`VoiceClient`."""
         gateway = 'wss://' + client.endpoint + '/?v=4'
         http = client._state.http

--- a/discord/http.py
+++ b/discord/http.py
@@ -58,6 +58,8 @@ from .flags import MessageFlags
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .file import File
     from .enums import (
         AuditLogAction,
@@ -94,7 +96,6 @@ if TYPE_CHECKING:
 
     T = TypeVar('T')
     BE = TypeVar('BE', bound=BaseException)
-    MU = TypeVar('MU', bound='MaybeUnlock')
     Response = Coroutine[Any, Any, T]
 
 
@@ -138,7 +139,7 @@ class MaybeUnlock:
         self.lock: asyncio.Lock = lock
         self._unlock: bool = True
 
-    def __enter__(self: MU) -> MU:
+    def __enter__(self) -> Self:
         return self
 
     def defer(self) -> None:

--- a/discord/invite.py
+++ b/discord/invite.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import List, Optional, Type, TypeVar, Union, ClassVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional, Union, ClassVar
 from .asset import Asset
 from .utils import parse_time, snowflake_time, _get_as_snowflake
 from .object import Object
@@ -40,6 +40,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .types.invite import (
         Invite as InvitePayload,
         VanityInvite as VanityInvitePayload,
@@ -216,9 +218,6 @@ class PartialInviteGuild:
         return Asset._from_guild_image(self._state, self.id, self._splash, path='splashes')
 
 
-I = TypeVar('I', bound='Invite')
-
-
 class Invite(Hashable):
     r"""Represents a Discord :class:`Guild` or :class:`abc.GuildChannel` invite.
 
@@ -392,7 +391,7 @@ class Invite(Hashable):
         )
 
     @classmethod
-    def from_incomplete(cls: Type[I], *, state: ConnectionState, data: InvitePayload) -> I:
+    def from_incomplete(cls, *, state: ConnectionState, data: InvitePayload) -> Self:
         guild: Optional[Union[Guild, PartialInviteGuild]]
         try:
             guild_data = data['guild']
@@ -416,7 +415,7 @@ class Invite(Hashable):
         return cls(state=state, data=data, guild=guild, channel=channel)
 
     @classmethod
-    def from_gateway(cls: Type[I], *, state: ConnectionState, data: GatewayInvitePayload) -> I:
+    def from_gateway(cls, *, state: ConnectionState, data: GatewayInvitePayload) -> Self:
         guild_id: Optional[int] = _get_as_snowflake(data, 'guild_id')
         guild: Optional[Union[Guild, Object]] = state._get_guild(guild_id)
         channel_id = int(data['channel_id'])

--- a/discord/member.py
+++ b/discord/member.py
@@ -29,7 +29,7 @@ import inspect
 import itertools
 import sys
 from operator import attrgetter
-from typing import Any, Dict, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union, Callable, Coroutine
+from typing import Any, Dict, List, Literal, Optional, TYPE_CHECKING, Tuple, Type, Union, Callable, Coroutine
 
 import discord.abc
 
@@ -49,6 +49,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .asset import Asset
     from .channel import DMChannel, VoiceChannel, StageChannel
     from .flags import PublicUserFlags
@@ -199,9 +201,6 @@ def flatten_user(cls) -> Type[Member]:
     return cls
 
 
-M = TypeVar('M', bound='Member')
-
-
 @flatten_user
 class Member(discord.abc.Messageable, _UserTag):
     """Represents a Discord member to a :class:`Guild`.
@@ -324,7 +323,7 @@ class Member(discord.abc.Messageable, _UserTag):
         return hash(self._user)
 
     @classmethod
-    def _from_message(cls: Type[M], *, message: Message, data: MemberPayload) -> M:
+    def _from_message(cls, *, message: Message, data: MemberPayload) -> Self:
         author = message.author
         data['user'] = author._to_minimal_user_json()
         return cls(data=data, guild=message.guild, state=message._state)  # type: ignore
@@ -338,7 +337,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
 
     @classmethod
-    def _try_upgrade(cls: Type[M], *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState) -> Union[User, M]:
+    def _try_upgrade(cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState) -> Union[User, Self]:
         # A User object with a 'member' key
         try:
             member_data = data.pop('member')
@@ -349,8 +348,8 @@ class Member(discord.abc.Messageable, _UserTag):
             return cls(data=member_data, guild=guild, state=state)  # type: ignore
 
     @classmethod
-    def _copy(cls: Type[M], member: M) -> M:
-        self: M = cls.__new__(cls)  # to bypass __init__
+    def _copy(cls, member: Self) -> Self:
+        self = cls.__new__(cls)  # to bypass __init__
 
         self._roles = utils.SnowflakeList(member._roles, is_sorted=True)
         self.joined_at = member.joined_at
@@ -369,7 +368,7 @@ class Member(discord.abc.Messageable, _UserTag):
         self._user = member._user
         return self
 
-    async def _get_channel(self):
+    async def _get_channel(self) -> DMChannel:
         ch = await self.create_dm()
         return ch
 

--- a/discord/mentions.py
+++ b/discord/mentions.py
@@ -23,14 +23,14 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import Type, TypeVar, Union, List, TYPE_CHECKING, Any, Union, Literal
+from typing import TYPE_CHECKING, Any, List, Union, Literal
 
 __all__ = (
     'AllowedMentions',
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeGuard
+    from typing_extensions import TypeGuard, Self
 
     from .types.message import AllowedMentions as AllowedMentionsPayload
     from .abc import Snowflake
@@ -48,8 +48,6 @@ class _FakeBool:
 
 
 default: Any = _FakeBool()
-
-A = TypeVar('A', bound='AllowedMentions')
 
 
 class AllowedMentions:
@@ -103,7 +101,7 @@ class AllowedMentions:
         self.replied_user: bool = replied_user
 
     @classmethod
-    def all(cls: Type[A]) -> A:
+    def all(cls) -> Self:
         """A factory method that returns a :class:`AllowedMentions` with all fields explicitly set to ``True``
 
         .. versionadded:: 1.5
@@ -111,7 +109,7 @@ class AllowedMentions:
         return cls(everyone=True, users=True, roles=True, replied_user=True)
 
     @classmethod
-    def none(cls: Type[A]) -> A:
+    def none(cls) -> Self:
         """A factory method that returns a :class:`AllowedMentions` with all fields set to ``False``
 
         .. versionadded:: 1.5

--- a/discord/message.py
+++ b/discord/message.py
@@ -66,6 +66,8 @@ from .sticker import StickerItem
 from .threads import Thread
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .types.message import (
         Message as MessagePayload,
         Attachment as AttachmentPayload,
@@ -94,7 +96,6 @@ if TYPE_CHECKING:
     from .webhook.async_ import _WebhookState
 
     T = TypeVar('T')
-    MR = TypeVar('MR', bound='MessageReference')
     EmojiInputType = Union[Emoji, PartialEmoji, str]
     CoroFunc = Callable[[], Coroutine[Any, Any, T]]
 
@@ -510,7 +511,7 @@ class MessageReference:
         self.fail_if_not_exists: bool = fail_if_not_exists
 
     @classmethod
-    def with_state(cls: Type[MR], state: ConnectionState, data: MessageReferencePayload) -> MR:
+    def with_state(cls, state: ConnectionState, data: MessageReferencePayload) -> Self:
         self = cls.__new__(cls)
         self.message_id = utils._get_as_snowflake(data, 'message_id')
         self.channel_id = int(data.pop('channel_id'))
@@ -521,7 +522,7 @@ class MessageReference:
         return self
 
     @classmethod
-    def from_message(cls: Type[MR], message: Message, *, fail_if_not_exists: bool = True) -> MR:
+    def from_message(cls, message: Message, *, fail_if_not_exists: bool = True) -> Self:
         """Creates a :class:`MessageReference` from an existing :class:`~discord.Message`.
 
         .. versionadded:: 1.6

--- a/discord/partial_emoji.py
+++ b/discord/partial_emoji.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, TYPE_CHECKING, Type, TypeVar, Union
+from typing import Any, Dict, Optional, TYPE_CHECKING, Union
 import re
 
 from .asset import Asset, AssetMixin
@@ -38,6 +38,8 @@ __all__ = (
 if TYPE_CHECKING:
     import datetime
 
+    from typing_extensions import Self
+
     from .types.message import PartialEmoji as PartialEmojiPayload
     from .state import ConnectionState
     from .webhook.async_ import _WebhookState
@@ -49,9 +51,6 @@ class _EmojiTag:
 
     def _to_partial(self) -> PartialEmoji:
         raise NotImplementedError
-
-
-PE = TypeVar('PE', bound='PartialEmoji')
 
 
 class PartialEmoji(_EmojiTag, AssetMixin):
@@ -103,7 +102,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         self._state: Optional[Union[ConnectionState, _WebhookState]] = None
 
     @classmethod
-    def from_dict(cls: Type[PE], data: Union[PartialEmojiPayload, Dict[str, Any]]) -> PE:
+    def from_dict(cls, data: Union[PartialEmojiPayload, Dict[str, Any]]) -> Self:
         return cls(
             animated=data.get('animated', False),
             id=utils._get_as_snowflake(data, 'id'),
@@ -111,7 +110,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         )
 
     @classmethod
-    def from_str(cls: Type[PE], value: str) -> PE:
+    def from_str(cls, value: str) -> Self:
         """Converts a Discord string representation of an emoji to a :class:`PartialEmoji`.
 
         The formats accepted are:
@@ -158,8 +157,8 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
     @classmethod
     def with_state(
-        cls: Type[PE], state: ConnectionState, *, name: Optional[str], animated: bool = False, id: Optional[int] = None
-    ) -> PE:
+        cls, state: ConnectionState, *, name: Optional[str], animated: bool = False, id: Optional[int] = None
+    ) -> Self:
         self = cls(name=name, animated=animated, id=id)
         self._state = state
         return self

--- a/discord/permissions.py
+++ b/discord/permissions.py
@@ -24,13 +24,16 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Callable, Any, ClassVar, Dict, Iterator, Set, TYPE_CHECKING, Tuple, Type, TypeVar, Optional
+from typing import Callable, Any, ClassVar, Dict, Iterator, Set, TYPE_CHECKING, Tuple, Optional
 from .flags import BaseFlags, flag_value, fill_with_flags, alias_flag_value
 
 __all__ = (
     'Permissions',
     'PermissionOverwrite',
 )
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 # A permission alias works like a regular flag but is marked
 # So the PermissionOverwrite knows to work with it
@@ -45,8 +48,6 @@ def make_permission_alias(alias: str) -> Callable[[Callable[[Any], int]], permis
         return ret
 
     return decorator
-
-P = TypeVar('P', bound='Permissions')
 
 @fill_with_flags()
 class Permissions(BaseFlags):
@@ -143,20 +144,20 @@ class Permissions(BaseFlags):
         __gt__ = is_strict_superset
 
     @classmethod
-    def none(cls: Type[P]) -> P:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``False``."""
         return cls(0)
 
     @classmethod
-    def all(cls: Type[P]) -> P:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
         return cls(0b11111111111111111111111111111111111111111)
 
     @classmethod
-    def all_channel(cls: Type[P]) -> P:
+    def all_channel(cls) -> Self:
         """A :class:`Permissions` with all channel-specific permissions set to
         ``True`` and the guild-specific ones set to ``False``. The guild-specific
         permissions are currently:
@@ -182,7 +183,7 @@ class Permissions(BaseFlags):
         return cls(0b111110110110011111101111111111101010001)
 
     @classmethod
-    def general(cls: Type[P]) -> P:
+    def general(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "General" permissions from the official Discord UI set to ``True``.
 
@@ -195,7 +196,7 @@ class Permissions(BaseFlags):
         return cls(0b01110000000010000000010010110000)
 
     @classmethod
-    def membership(cls: Type[P]) -> P:
+    def membership(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Membership" permissions from the official Discord UI set to ``True``.
 
@@ -207,7 +208,7 @@ class Permissions(BaseFlags):
         return cls(0b10000000000001100000000000000000000000111)
 
     @classmethod
-    def text(cls: Type[P]) -> P:
+    def text(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Text" permissions from the official Discord UI set to ``True``.
 
@@ -222,7 +223,7 @@ class Permissions(BaseFlags):
         return cls(0b111110010000000000001111111100001000000)
 
     @classmethod
-    def voice(cls: Type[P]) -> P:
+    def voice(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Voice" permissions from the official Discord UI set to ``True``.
         
@@ -232,7 +233,7 @@ class Permissions(BaseFlags):
         return cls(0b1000000000000011111100000000001100000000)
 
     @classmethod
-    def stage(cls: Type[P]) -> P:
+    def stage(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Stage Channel" permissions from the official Discord UI set to ``True``.
 
@@ -241,7 +242,7 @@ class Permissions(BaseFlags):
         return cls(1 << 32)
 
     @classmethod
-    def stage_moderator(cls: Type[P]) -> P:
+    def stage_moderator(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Stage Moderator" permissions from the official Discord UI set to ``True``.
 
@@ -250,7 +251,7 @@ class Permissions(BaseFlags):
         return cls(0b100000001010000000000000000000000)
 
     @classmethod
-    def advanced(cls: Type[P]) -> P:
+    def advanced(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Advanced" permissions from the official Discord UI set to ``True``.
 
@@ -588,8 +589,6 @@ class Permissions(BaseFlags):
         """
         return 1 << 40
 
-PO = TypeVar('PO', bound='PermissionOverwrite')
-
 def _augment_from_permissions(cls):
     cls.VALID_NAMES = set(Permissions.VALID_FLAGS)
     aliases = set()
@@ -740,7 +739,7 @@ class PermissionOverwrite:
         return allow, deny
 
     @classmethod
-    def from_pair(cls: Type[PO], allow: Permissions, deny: Permissions) -> PO:
+    def from_pair(cls, allow: Permissions, deny: Permissions) -> Self:
         """Creates an overwrite from an allow/deny pair of :class:`Permissions`."""
         ret = cls()
         for key, value in allow:

--- a/discord/player.py
+++ b/discord/player.py
@@ -36,7 +36,7 @@ import sys
 import re
 import io
 
-from typing import Any, Callable,  Generic, IO, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Generic, IO, Optional, TYPE_CHECKING, Tuple, TypeVar, Union
 
 from .errors import ClientException
 from .opus import Encoder as OpusEncoder
@@ -44,11 +44,12 @@ from .oggparse import OggStream
 from .utils import MISSING
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .voice_client import VoiceClient
 
 
 AT = TypeVar('AT', bound='AudioSource')
-FT = TypeVar('FT', bound='FFmpegOpusAudio')
 
 _log = logging.getLogger(__name__)
 
@@ -385,12 +386,12 @@ class FFmpegOpusAudio(FFmpegAudio):
 
     @classmethod
     async def from_probe(
-        cls: Type[FT],
+        cls,
         source: str,
         *,
         method: Optional[Union[str, Callable[[str, str], Tuple[Optional[str], Optional[int]]]]] = None,
         **kwargs: Any,
-    ) -> FT:
+    ) -> Self:
         """|coro|
 
         A factory method that creates a :class:`FFmpegOpusAudio` after probing

--- a/discord/raw_models.py
+++ b/discord/raw_models.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Set, List, Union
+from typing import TYPE_CHECKING, Optional, Set, List, Union, Tuple
 
 from .utils import _get_as_snowflake
 
@@ -62,6 +62,8 @@ __all__ = (
 
 
 class _RawReprMixin:
+    __slots__: Tuple[str, ...]
+
     def __repr__(self) -> str:
         value = ' '.join(f'{attr}={getattr(self, attr)!r}' for attr in self.__slots__)
         return f'<{self.__class__.__name__} {value}>'

--- a/discord/role.py
+++ b/discord/role.py
@@ -23,7 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import Any, Dict, List, Optional, TypeVar, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
 from .permissions import Permissions
 from .errors import InvalidArgument
@@ -38,6 +38,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     import datetime
     from .types.role import (
         Role as RolePayload,
@@ -100,9 +102,6 @@ class RoleTags:
             f'<RoleTags bot_id={self.bot_id} integration_id={self.integration_id} '
             f'premium_subscriber={self.is_premium_subscriber()}>'
         )
-
-
-R = TypeVar('R', bound='Role')
 
 
 class Role(Hashable):
@@ -203,7 +202,7 @@ class Role(Hashable):
     def __repr__(self) -> str:
         return f'<Role id={self.id} name={self.name!r}>'
 
-    def __lt__(self: R, other: R) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, Role) or not isinstance(self, Role):
             return NotImplemented
 
@@ -224,16 +223,16 @@ class Role(Hashable):
 
         return False
 
-    def __le__(self: R, other: R) -> bool:
+    def __le__(self, other: Self) -> bool:
         r = Role.__lt__(other, self)
         if r is NotImplemented:
             return NotImplemented
         return not r
 
-    def __gt__(self: R, other: R) -> bool:
+    def __gt__(self, other: Self) -> bool:
         return Role.__lt__(other, self)
 
-    def __ge__(self: R, other: R) -> bool:
+    def __ge__(self, other: Self) -> bool:
         r = Role.__lt__(self, other)
         if r is NotImplemented:
             return NotImplemented

--- a/discord/shard.py
+++ b/discord/shard.py
@@ -43,14 +43,14 @@ from .errors import (
 
 from .enums import Status, Enum
 
-from typing import TYPE_CHECKING, Any, Callable, Tuple, Type, Optional, List, Dict, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Tuple, Type, Optional, List, Dict, overload
 
 if TYPE_CHECKING:
+    from typing_extensions import Self    
+
     from .gateway import DiscordWebSocket
     from .activity import BaseActivity
     from .enums import Status
-
-    EI = TypeVar('EI', bound='EventItem')
 
 __all__ = (
     'AutoShardedClient',
@@ -77,12 +77,12 @@ class EventItem:
         self.shard: Optional[Shard] = shard
         self.error: Optional[Exception] = error
 
-    def __lt__(self: EI, other: EI) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, EventItem):
             return NotImplemented
         return self.type < other.type
 
-    def __eq__(self: EI, other: EI) -> bool:
+    def __eq__(self, other: Self) -> bool:
         if not isinstance(other, EventItem):
             return NotImplemented
         return self.type == other.type

--- a/discord/state.py
+++ b/discord/state.py
@@ -123,7 +123,6 @@ if TYPE_CHECKING:
         ScheduledEventUserEvent,
     )
 
-    CS = TypeVar('CS', bound='ConnectionState')
     Channel = Union[GuildChannel, VocalGuildChannel, PrivateChannel]
 
 

--- a/discord/threads.py
+++ b/discord/threads.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Iterable, List, Optional, Union, TypeVar, TYPE_CHECKING
+from typing import Callable, Dict, Iterable, List, Optional, Union, TYPE_CHECKING
 import time
 import asyncio
 
@@ -40,6 +40,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .types.threads import (
         Thread as ThreadPayload,
         ThreadMember as ThreadMemberPayload,
@@ -57,8 +59,6 @@ if TYPE_CHECKING:
     from .state import ConnectionState
 
     import datetime
-
-    ThreadT = TypeVar('ThreadT', bound='Thread')
 
 class Thread(Messageable, Hashable):
     """Represents a Discord thread.
@@ -154,7 +154,7 @@ class Thread(Messageable, Hashable):
         self._members: Dict[int, ThreadMember] = {}
         self._from_data(data)
 
-    async def _get_channel(self: ThreadT) -> ThreadT:
+    async def _get_channel(self) -> Self:
         return self
 
     def __repr__(self) -> str:

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -40,6 +40,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..types.components import (
         ButtonComponent as ButtonComponentPayload
     )

--- a/discord/ui/button.py
+++ b/discord/ui/button.py
@@ -200,7 +200,7 @@ class Button(Item[V]):
             self._underlying.emoji = None
 
     @classmethod
-    def from_component(cls: Type[B], button: ButtonComponent) -> B:
+    def from_component(cls, button: ButtonComponent) -> Self:
         return cls(
             style=button.style,
             label=button.label,

--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -77,7 +77,7 @@ class Item(Generic[V]):
         return None
 
     @classmethod
-    def from_component(cls: Type[I], component: Component) -> I:
+    def from_component(cls, component: Component) -> Self:
         return cls()
 
     @property

--- a/discord/ui/item.py
+++ b/discord/ui/item.py
@@ -33,6 +33,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..enums import ComponentType
     from .view import View
     from ..components import Component

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -275,7 +275,7 @@ class Select(Item[V]):
         self._selected_values = data.get('values', [])
 
     @classmethod
-    def from_component(cls: Type[S], component: SelectMenu) -> S:
+    def from_component(cls, component: SelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/discord/ui/select.py
+++ b/discord/ui/select.py
@@ -44,6 +44,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .view import View
     from ..types.components import SelectMenu as SelectMenuPayload
     from ..types.interactions import (

--- a/discord/user.py
+++ b/discord/user.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Type, TypeVar, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 import discord.abc
 from .asset import Asset
@@ -34,6 +34,8 @@ from .flags import PublicUserFlags
 from .utils import snowflake_time, _bytes_to_base64_data, MISSING
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from datetime import datetime
 
     from .channel import DMChannel
@@ -49,8 +51,6 @@ __all__ = (
     'User',
     'ClientUser',
 )
-
-BU = TypeVar('BU', bound='BaseUser')
 
 
 class _UserTag:
@@ -106,7 +106,7 @@ class BaseUser(_UserTag):
         self.system: bool = data.get('system', False)
 
     @classmethod
-    def _copy(cls: Type[BU], user: BU) -> BU:
+    def _copy(cls, user: Self) -> Self:
         self = cls.__new__(cls)  # bypass __init__
 
         self.name = user.name

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -72,6 +72,8 @@ else:
     HAS_ORJSON = True
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .file import File
 
 
@@ -92,7 +94,6 @@ __all__ = (
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
-SLT = TypeVar('SLT', bound='SnowflakeList')
 
 DISCORD_EPOCH = 1420070400000
 
@@ -658,7 +659,7 @@ class SnowflakeList(_SnowflakeListBase):
         def __init__(self, data: Iterable[int], *, is_sorted: bool = False) -> None:
             ...
 
-    def __new__(cls: Type[SLT], data: Iterable[int], *, is_sorted: bool = False) -> SLT:
+    def __new__(cls, data: Iterable[int], *, is_sorted: bool = False) -> Self:
         return array.array.__new__(cls, 'Q', data if is_sorted else sorted(data))  # type: ignore
 
     def add(self, element: int) -> None:

--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -30,7 +30,7 @@ import json
 import re
 
 from urllib.parse import quote as urlquote
-from typing import Any, Dict, List, Literal, NamedTuple, Optional, TYPE_CHECKING, Tuple, Union, TypeVar, Type, overload
+from typing import Any, Dict, List, Literal, NamedTuple, Optional, TYPE_CHECKING, Tuple, Union, Type, overload
 from contextvars import ContextVar
 
 import aiohttp
@@ -55,6 +55,8 @@ __all__ = (
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..types.webhook import (
         Webhook as WebhookPayload,
         SourceGuild as SourceGuildPayload,
@@ -83,9 +85,6 @@ if TYPE_CHECKING:
     from types import TracebackType
     import datetime
 
-    WT = TypeVar('WT', bound='Webhook')
-    ADLT = TypeVar('ADLT', bound='AsyncDeferredLock')
-
 MISSING = utils.MISSING
 
 
@@ -94,7 +93,7 @@ class AsyncDeferredLock:
         self.lock: asyncio.Lock = lock
         self.delta: Optional[float] = None
 
-    async def __aenter__(self: ADLT) -> ADLT:
+    async def __aenter__(self) -> Self:
         await self.lock.acquire()
         return self
 
@@ -991,7 +990,7 @@ class Webhook(BaseWebhook):
         return f'https://discord.com/api/webhooks/{self.id}/{self.token}'
 
     @classmethod
-    def partial(cls: Type[WT], id: int, token: str, *, session: aiohttp.ClientSession, bot_token: Optional[str] = None) -> Webhook:
+    def partial(cls, id: int, token: str, *, session: aiohttp.ClientSession, bot_token: Optional[str] = None) -> Self:
         """Creates a partial :class:`Webhook`.
 
         Parameters
@@ -1027,7 +1026,7 @@ class Webhook(BaseWebhook):
         return cls(data, session, token=bot_token)
 
     @classmethod
-    def from_url(cls: Type[WT], url: str, *, session: aiohttp.ClientSession, bot_token: Optional[str] = None) -> WT:
+    def from_url(cls, url: str, *, session: aiohttp.ClientSession, bot_token: Optional[str] = None) -> Self:
         """Creates a partial :class:`Webhook` from a webhook URL.
 
         Parameters
@@ -1066,7 +1065,7 @@ class Webhook(BaseWebhook):
         return cls(data, session, token=bot_token)  # type: ignore
 
     @classmethod
-    def _as_follower(cls: Type[WT], data: FollowedChannel, *, channel: TextChannel, user) -> WT:
+    def _as_follower(cls, data: FollowedChannel, *, channel: TextChannel, user) -> Self:
         name = f"{channel.guild} #{channel}"
         feed: WebhookPayload = {
             'id': data['webhook_id'],
@@ -1087,7 +1086,7 @@ class Webhook(BaseWebhook):
         return cls(feed, session=session, state=state, token=state.http.token)
 
     @classmethod
-    def from_state(cls: Type[WT], data: WebhookPayload, state: ConnectionState) -> WT:
+    def from_state(cls, data: WebhookPayload, state: ConnectionState) -> Self:
         session = state.http._HTTPClient__session  # type: ignore
         return cls(data, session=session, state=state, token=state.http.token)
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -55,6 +55,8 @@ __all__ = (
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..file import File
     from ..embeds import Embed
     from ..mentions import AllowedMentions
@@ -71,8 +73,6 @@ if TYPE_CHECKING:
     from types import TracebackType
     from requests import Session, Response
 
-    DLT = TypeVar('DLT', bound='DeferredLock')
-    SWT = TypeVar('SWT', bound='SyncWebhook')
     T = TypeVar('T')
 
 MISSING = utils.MISSING
@@ -83,7 +83,7 @@ class DeferredLock:
         self.lock: threading.Lock = lock
         self.delta: Optional[float] = None
 
-    def __enter__(self: DLT) -> DLT:
+    def __enter__(self) -> Self:
         self.lock.acquire()
         return self
 
@@ -586,7 +586,7 @@ class SyncWebhook(BaseWebhook):
         return f'https://discord.com/api/webhooks/{self.id}/{self.token}'
 
     @classmethod
-    def partial(cls: Type[SWT], id: int, token: str, *, session: Session = MISSING, bot_token: Optional[str] = None) -> SWT:
+    def partial(cls, id: int, token: str, *, session: Session = MISSING, bot_token: Optional[str] = None) -> Self:
         """Creates a partial :class:`Webhook`.
 
         Parameters
@@ -625,7 +625,7 @@ class SyncWebhook(BaseWebhook):
         return cls(data, session, token=bot_token)
 
     @classmethod
-    def from_url(cls: Type[SWT], url: str, *, session: Session = MISSING, bot_token: Optional[str] = None) -> SyncWebhook:
+    def from_url(cls, url: str, *, session: Session = MISSING, bot_token: Optional[str] = None) -> Self:
         """Creates a partial :class:`Webhook` from a webhook URL.
 
         Parameters

--- a/discord/welcome_screen.py
+++ b/discord/welcome_screen.py
@@ -24,12 +24,14 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, List, TypeVar, Type, Union
+from typing import TYPE_CHECKING, Optional, List, Union
 
 from .utils import MISSING, _get_as_snowflake
 from .partial_emoji import PartialEmoji
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .state import ConnectionState
     from .channel import TextChannel
     from .guild import Guild
@@ -41,8 +43,6 @@ if TYPE_CHECKING:
         EditWelcomeScreen as EditWelcomeScreenPayload,
     )
     from .types.emoji import Emoji as EmojiPayload
-
-    WCT = TypeVar('WCT', bound='WelcomeScreenChannel')
 
 
 __all__ = (
@@ -93,7 +93,7 @@ class WelcomeScreen:
         welcome_channels: Optional[List[WelcomeScreenChannel]] = MISSING,
         description: Optional[str] = MISSING,
         reason: Optional[str] = None,
-    ) -> WelcomeScreen:
+    ) -> Self:
         """|coro|
 
         Edits the welcome screen in place.
@@ -185,7 +185,7 @@ class WelcomeScreenChannel:
         return state and state.get_channel(self.channel_id)  # type: ignore
 
     @classmethod
-    def from_data(cls: Type[WCT], *, parent: WelcomeScreen, data: WelcomeScreenChannelPayload) -> WCT:
+    def from_data(cls, *, parent: WelcomeScreen, data: WelcomeScreenChannelPayload) -> Self:
         channel_id = int(data['channel_id'])
         description = data['description']
         emoji_name = data['emoji_name']


### PR DESCRIPTION
## Summary
This PR uses `typing_extensions.Self` instead of `TypeVar`s where applicable.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
