### PR TITLE
Add the suppress parameter to Webhook and SyncWebhook.send

### DIFF
--- a/discord/webhook/async_.py
+++ b/discord/webhook/async_.py
@@ -558,7 +558,7 @@ def handle_message_parameters(
     if files:
         form = utils._generate_multipart(payload, files)
         payload = None
-    print(payload)
+
     return ExecuteWebhookParameters(payload=payload, multipart=form, files=files)
 
 

--- a/discord/webhook/sync.py
+++ b/discord/webhook/sync.py
@@ -830,12 +830,27 @@ class SyncWebhook(BaseWebhook):
         username: str = MISSING,
         avatar_url: Any = MISSING,
         tts: bool = MISSING,
-        file: File = MISSING,
         files: List[File] = MISSING,
-        embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         wait: Literal[True],
+        suppress: bool = False,
+    ) -> SyncWebhookMessage:
+        ...
+
+    @overload
+    def send(
+        self,
+        content: str = MISSING,
+        *,
+        username: str = MISSING,
+        avatar_url: Any = MISSING,
+        tts: bool = MISSING,
+        files: List[File] = MISSING,
+        embed: Embed = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        wait: Literal[True],
+        suppress: bool = False,
     ) -> SyncWebhookMessage:
         ...
 
@@ -848,11 +863,90 @@ class SyncWebhook(BaseWebhook):
         avatar_url: Any = MISSING,
         tts: bool = MISSING,
         file: File = MISSING,
-        files: List[File] = MISSING,
+        embeds: List[Embed] = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        wait: Literal[True],
+        suppress: bool = False,
+    ) -> SyncWebhookMessage:
+        ...
+
+    @overload
+    def send(
+        self,
+        content: str = MISSING,
+        *,
+        username: str = MISSING,
+        avatar_url: Any = MISSING,
+        tts: bool = MISSING,
+        file: File = MISSING,
         embed: Embed = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        wait: Literal[True],
+        suppress: bool = False,
+    ) -> SyncWebhookMessage:
+        ...
+
+    @overload
+    def send(
+        self,
+        content: str = MISSING,
+        *,
+        username: str = MISSING,
+        avatar_url: Any = MISSING,
+        tts: bool = MISSING,
+        files: List[File] = MISSING,
         embeds: List[Embed] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         wait: Literal[False] = ...,
+        suppress: bool = False,
+    ) -> None:
+        ...
+
+    @overload
+    def send(
+        self,
+        content: str = MISSING,
+        *,
+        username: str = MISSING,
+        avatar_url: Any = MISSING,
+        tts: bool = MISSING,
+        files: List[File] = MISSING,
+        embed: Embed = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        wait: Literal[False] = ...,
+        suppress: bool = False,
+    ) -> None:
+        ...
+
+    @overload
+    def send(
+        self,
+        content: str = MISSING,
+        *,
+        username: str = MISSING,
+        avatar_url: Any = MISSING,
+        tts: bool = MISSING,
+        file: File = MISSING,
+        embeds: List[Embed] = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        wait: Literal[False] = ...,
+        suppress: bool = False,
+    ) -> None:
+        ...
+
+    @overload
+    def send(
+        self,
+        content: str = MISSING,
+        *,
+        username: str = MISSING,
+        avatar_url: Any = MISSING,
+        tts: bool = MISSING,
+        file: File = MISSING,
+        embed: Embed = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        wait: Literal[False] = ...,
+        suppress: bool = False,
     ) -> None:
         ...
 
@@ -870,6 +964,7 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
         wait: bool = False,
+        suppress: bool = False,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
 
@@ -918,6 +1013,10 @@ class SyncWebhook(BaseWebhook):
             The thread to send this message to.
 
             .. versionadded:: 2.0
+        suppress: :class:`bool`
+            Whether to suppress embeds for the message. This removes all the embeds if set to ``True``.
+
+            .. versionadded:: 2.0
 
         Raises
         --------
@@ -958,6 +1057,7 @@ class SyncWebhook(BaseWebhook):
             embeds=embeds,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            suppress=suppress,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
         thread_id: Optional[int] = None


### PR DESCRIPTION
## Summary
This PR is an addition to #13 that adds the ``suppress`` parameter to ``Webhook.send`` and ``SyncWebhook.send``.

Note: this pull request still needs to be tested.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
